### PR TITLE
@anchpop/custom keyboard

### DIFF
--- a/Trickle.xcodeproj/project.pbxproj
+++ b/Trickle.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		ABD497652C6484BF00707842 /* TrickleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD497642C6484BF00707842 /* TrickleBackground.swift */; };
 		ABD497672C6484E400707842 /* TrickleForeground.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD497662C6484E400707842 /* TrickleForeground.swift */; };
 		ABD497692C64870900707842 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD497682C64870900707842 /* SettingsView.swift */; };
+		ABD497722C649D9500707842 /* CustomTFKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD497712C649D9400707842 /* CustomTFKeyboard.swift */; };
+		ABD497742C64AF6F00707842 /* CalculatorKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD497732C64AF6F00707842 /* CalculatorKeyboard.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,6 +121,8 @@
 		ABD497642C6484BF00707842 /* TrickleBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrickleBackground.swift; sourceTree = "<group>"; };
 		ABD497662C6484E400707842 /* TrickleForeground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrickleForeground.swift; sourceTree = "<group>"; };
 		ABD497682C64870900707842 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		ABD497712C649D9400707842 /* CustomTFKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTFKeyboard.swift; sourceTree = "<group>"; };
+		ABD497732C64AF6F00707842 /* CalculatorKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorKeyboard.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +191,7 @@
 		AB2D2B932BFC4E5200F03DFD /* Trickle */ = {
 			isa = PBXGroup;
 			children = (
+				ABD4976E2C649BB300707842 /* CalculatorKeyboard */,
 				AB78A4922C39D66A007C4787 /* Trickle.entitlements */,
 				AB2D2B942BFC4E5200F03DFD /* TrickleApp.swift */,
 				AB2D2B962BFC4E5200F03DFD /* ContentView.swift */,
@@ -250,6 +255,15 @@
 				AB78A4C52C5DD5A3007C4787 /* Info.plist */,
 			);
 			path = AddApplePayTransactionShortcut;
+			sourceTree = "<group>";
+		};
+		ABD4976E2C649BB300707842 /* CalculatorKeyboard */ = {
+			isa = PBXGroup;
+			children = (
+				ABD497712C649D9400707842 /* CustomTFKeyboard.swift */,
+				ABD497732C64AF6F00707842 /* CalculatorKeyboard.swift */,
+			);
+			path = CalculatorKeyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -434,8 +448,10 @@
 				AB2D2B972BFC4E5200F03DFD /* ContentView.swift in Sources */,
 				AB1669312C5F035B0048A993 /* CalendarStrip.swift in Sources */,
 				ABD497672C6484E400707842 /* TrickleForeground.swift in Sources */,
+				ABD497742C64AF6F00707842 /* CalculatorKeyboard.swift in Sources */,
 				AB7B79282C602FFB003647EF /* Intro.swift in Sources */,
 				ABD497652C6484BF00707842 /* TrickleBackground.swift in Sources */,
+				ABD497722C649D9500707842 /* CustomTFKeyboard.swift in Sources */,
 				AB2D2B952BFC4E5200F03DFD /* TrickleApp.swift in Sources */,
 				AB7B79262C6011FA003647EF /* Expression.swift in Sources */,
 				ABD497692C64870900707842 /* SettingsView.swift in Sources */,

--- a/Trickle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Trickle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e560c2af3bb27ba1b8a6ab330dd4a059de56e2b3023b11347bc61f26d063d1c3",
+  "originHash" : "9f004fcef786ced3cabe2c093e6e5805c95d13b76b308c84dc37df5c9e480514",
   "pins" : [
     {
       "identity" : "oklab",

--- a/Trickle/CalculatorKeyboard/CalculatorKeyboard.swift
+++ b/Trickle/CalculatorKeyboard/CalculatorKeyboard.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+enum KeyboardValue {
+    case number(String)
+    case operation(String)
+    case image(String)
+    case action(String)
+    case next(String)
+}
+
+struct CalculatorKeyboard: KeyboardContent {
+    init(
+        text: Binding<String>,
+        selectedText: Binding<String>,
+        onSubmit: @escaping (() -> Void),
+        onBackspace: @escaping (() -> Void),
+        getCharBeforeCursor: @escaping (() -> Character?)
+    ) {
+        _text = text
+        _selectedText = selectedText
+        self.onSubmit = onSubmit
+        self.onBackspace = onBackspace
+        self.getCharBeforeCursor = getCharBeforeCursor
+    }
+    
+    @Binding var text: String
+    @Binding var selectedText: String
+
+    var onSubmit: (() -> Void)
+    var onBackspace: (() -> Void)
+    var getCharBeforeCursor: (() -> Character?)
+    @State private var selectionRange: Range<String.Index>?
+
+    var body: some View {
+        VStack(spacing: 6) {
+            // slightly larger spacing between buttons and numbers
+            HStack(spacing: 9) {
+                VStack(spacing: 6) {
+                    HStack(spacing: 6) {
+                        ForEach(1...3, id: \.self) { index in
+                            KeyboardButtonView(value: .number("\(index)")) {
+                                selectedText = "\(index)"
+                            }
+                        }
+                    }
+                    HStack(spacing: 6) {
+                        ForEach(4...6, id: \.self) { index in
+                            KeyboardButtonView(value: .number("\(index)")) {
+                                selectedText = "\(index)"
+                            }
+                        }
+                    }
+                    HStack(spacing: 6) {
+                        ForEach(7...9, id: \.self) { index in
+                            KeyboardButtonView(value: .number("\(index)")) {
+                                selectedText = "\(index)"
+                            }
+                        }
+                    }
+                    HStack(spacing: 6) {
+                        KeyboardButtonView(
+                            value: .operation("."),
+                            disabled: inputContainsDecimal()
+                        ) {
+                            selectedText = "."
+                        }
+                        KeyboardButtonView(value: .number("0")) {
+                            selectedText = "0"
+                        }
+                        KeyboardButtonView(value: .image("delete.left")) {
+                            onBackspace()
+                        }
+                    }
+                }
+                
+                VStack(spacing: 6) {
+                    ForEach(["+", "-", "×", "÷"], id: \.self) { operation in
+                        KeyboardButtonView(
+                            value: .operation(operation),
+                            disabled: shouldDisableOperation(operation),
+                            onTap: {
+                                selectedText = operation
+                            }
+                        )
+                        .frame(maxHeight: .infinity)
+                    }
+                }
+                .frame(width: 50)
+            }
+            
+            KeyboardButtonView(value: .next("Next")) {
+                onSubmit()
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+        }
+        .padding(6)
+        .background(Color(.systemGray6))
+    }
+
+    func onSelectionChange(start: Int, end: Int) {
+        let startIndex = text.index(text.startIndex, offsetBy: start)
+        let endIndex = text.index(text.startIndex, offsetBy: end)
+        selectionRange = startIndex..<endIndex
+    }
+    
+    private func shouldDisableOperation(_ operation: String) -> Bool {
+        guard let charBeforeCursor = getCharBeforeCursor() else {
+            return operation != "-"
+        }
+        return !charBeforeCursor.isNumber && operation != "-"
+    }
+    
+    private func inputContainsDecimal() -> Bool {
+        return text.contains(".")
+    }
+}
+
+struct KeyboardButtonView: View {
+    let value: KeyboardValue
+    var disabled: Bool = false
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: {
+            if case .next = value {
+                // Don't play haptic for the "Next" button
+            } else {
+                playHapticFeedback()
+            }
+
+            onTap()
+        }) {
+            ZStack {
+                switch value {
+                case .number(let string), .operation(let string), .action(let string):
+                    Text(string)
+                        .font(.title3)
+                        .fontWeight(.regular)
+                case .next(let string):
+                    Text(string)
+                        .font(.title3)
+                        .fontWeight(.regular)
+                        .foregroundStyle(Color.accentColor)
+                case .image(let image):
+                    Image(systemName: image)
+                        .font(.title3)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(backgroundColor)
+            .cornerRadius(5)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .disabled(disabled)
+        .opacity(disabled ? 0.5 : 1.0)
+    }
+    
+    private var backgroundColor: Color {
+        switch value {
+        case .number:
+            return Color(.systemBackground)
+        case .operation, .image, .action, .next:
+            return Color(.systemGray4)
+        }
+    }
+    
+    private func playHapticFeedback() {
+        let impact = UIImpactFeedbackGenerator(style: .light)
+        impact.impactOccurred()
+    }
+
+}
+
+
+#Preview {
+    @State var inputAmount = ""
+    
+    return ZStack {
+        Color(.systemBackground)
+        CalculatorKeyboard(
+            text: $inputAmount,
+            selectedText: $inputAmount,
+            onSubmit: {},
+            onBackspace: {},
+            getCharBeforeCursor: {nil}
+        )
+    }
+}

--- a/Trickle/CalculatorKeyboard/CustomTFKeyboard.swift
+++ b/Trickle/CalculatorKeyboard/CustomTFKeyboard.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// Custom TextField Keyboard TextField Modifier
+extension TextField {
+    @ViewBuilder
+    func inputView<Content: KeyboardContent>(
+        _ dump: Content.Type,
+        text: Binding<String>,
+        onSubmit: @escaping (() -> Void) = {}
+    ) -> some View {
+        self
+            .background {
+                SetTFKeyboard<Content, Label>(text: text, onSubmit: onSubmit, textField: self)
+            }
+    }
+}
+
+fileprivate struct SetTFKeyboard<Content: KeyboardContent, Label: View>: UIViewRepresentable {
+    @Binding var text: String
+    let onSubmit: (() -> Void)
+    let textField: TextField<Label>
+    @State private var selectedRange: Range<String.Index> = Range(uncheckedBounds: ("".startIndex, "".endIndex))
+    
+    @State private var hostingController: UIHostingController<Content>?
+    
+    func makeUIView(context: Context) -> UIView {
+        return UIView()
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+    
+    var content: Content {
+        let selectedText = Binding(
+            get: {
+                // Validate that selectedRange is within the text's bounds
+                guard selectedRange.lowerBound >= text.startIndex && selectedRange.upperBound <= text.endIndex else {
+                    return ""
+                }
+                return String(text[selectedRange])
+            },
+            set: { newValue in
+                DispatchQueue.main.async {
+                    // Check again when setting the new value
+                    guard selectedRange.lowerBound >= text.startIndex && selectedRange.upperBound <= text.endIndex else {
+                        return
+                    }
+                    text.replaceSubrange(selectedRange, with: newValue)
+                    // Update the selectedRange to be at the end of the newly inserted text
+                    let newEndIndex = text.index(selectedRange.lowerBound, offsetBy: newValue.count)
+                    selectedRange = newEndIndex..<newEndIndex
+                }
+            }
+        )
+        return Content(text: $text, selectedText: selectedText, onSubmit: onSubmit, onBackspace: backspace, getCharBeforeCursor: getCharBeforeCursor)
+    }
+    
+    func getCharBeforeCursor() -> Character? {
+        let cursorPosition = min(selectedRange.lowerBound, text.endIndex)
+        guard cursorPosition > text.startIndex,
+              !text.isEmpty else { return nil }
+        
+        let indexBeforeCursor = text.index(before: cursorPosition)
+        guard indexBeforeCursor >= text.startIndex else { return nil }
+        
+        return text[indexBeforeCursor]
+    }
+    
+    func backspace() {
+        if selectedRange.isEmpty {
+            // If no selection, delete the character before the cursor
+            if let index = text.index(selectedRange.lowerBound, offsetBy: -1, limitedBy: text.startIndex) {
+                text.remove(at: index)
+                selectedRange = index..<index
+            }
+        } else {
+            // If there's a selection, delete the selected text
+            text.removeSubrange(selectedRange)
+            selectedRange = selectedRange.lowerBound..<selectedRange.lowerBound
+        }
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {
+        DispatchQueue.main.async {
+            if let textFieldContainerView = uiView.superview?.superview {
+                if let uiTextField = textField.getUITextField(in: textFieldContainerView) {
+                    if uiTextField.inputView == nil {
+                        hostingController = UIHostingController(rootView: content)
+                        hostingController?.view.frame = .init(origin: .zero, size: hostingController?.view.intrinsicContentSize ?? .zero)
+                        uiTextField.delegate = context.coordinator
+                        uiTextField.inputView = hostingController?.view
+                        uiTextField.reloadInputViews()
+                    } else {
+                        hostingController?.rootView = content
+                    }
+                }
+                else {
+                    print("Not able to get text field \(textField) in \(textFieldContainerView)")
+                }
+            }
+            else {
+                print("Something was nil: (uiView.superview \(String(describing: uiView.superview)))?.superview / \(String(describing: uiView.superview?.superview))")
+            }
+        }
+    }
+    
+    class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: SetTFKeyboard
+        
+        init(_ parent: SetTFKeyboard) {
+            self.parent = parent
+        }
+        
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                textField.reloadInputViews()
+            }
+        }
+        
+        func textFieldDidChangeSelection(_ textField: UITextField) {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                guard let newSelectedRange = textField.selectedTextRange else { return }
+                
+                let selectionStart = textField.offset(from: textField.beginningOfDocument, to: newSelectedRange.start)
+                let selectionEnd = textField.offset(from: textField.beginningOfDocument, to: newSelectedRange.end)
+                
+                // Ensure that the offsets do not exceed the bounds of the text
+                let safeStartIndex = min(max(selectionStart, 0), self.parent.text.count)
+                let safeEndIndex = min(max(selectionEnd, 0), self.parent.text.count)
+
+                let startIndex = self.parent.text.index(self.parent.text.startIndex, offsetBy: safeStartIndex)
+                let endIndex = self.parent.text.index(self.parent.text.startIndex, offsetBy: safeEndIndex)
+                
+                self.parent.selectedRange = startIndex..<endIndex
+                
+                print("text.indices.contains(safeStartIndex)", self.parent.text.indices.contains(startIndex), " | newSelectedRange", newSelectedRange, " | startIndex", startIndex.utf16Offset(in: self.parent.text))
+                
+                // Update the custom keyboard view
+                if let hostingController = self.parent.hostingController {
+                    hostingController.rootView.onSelectionChange(start: safeStartIndex, end: safeEndIndex)
+                }
+            }
+        }
+    }
+}
+protocol KeyboardContent: View {
+    func onSelectionChange(start: Int, end: Int)
+    
+    init(
+        text: Binding<String>, selectedText: Binding<String>,
+        onSubmit: @escaping (() -> Void),
+        onBackspace: @escaping (() -> Void),
+        getCharBeforeCursor: @escaping (() -> Character?)
+    )
+}
+
+extension TextField {
+    func getUITextField(in view: UIView) -> UITextField? {
+        for subview in view.allSubViews {
+            if let textField = subview as? UITextField {
+                return textField
+            }
+        }
+        return nil
+    }
+}
+
+/// Extracting TextField From the Subviews
+fileprivate extension UIView {
+    var allSubViews: [UIView] {
+        return subviews.flatMap { [$0] + $0.subviews }
+    }
+    
+    /// Finding the UIView is TextField or Not
+    func findTextField(_ hint: String) -> UITextField? {
+        if let textField = allSubViews.first(where: { view in
+             let tf = view as? UITextField
+            return tf?.placeholder == hint
+        }) as? UITextField {
+            return textField
+        }
+        
+        return nil
+    }
+}

--- a/Trickle/Intro.swift
+++ b/Trickle/Intro.swift
@@ -32,6 +32,7 @@ struct Intro: View {
     @State private var currentPage: Int = 1 // New state variable to track the current page
     @State private var currentTime: Date = Date()
     @State private var startDate: Date = Date()
+    @FocusState private var focusedField: Bool
     
     @Environment(\.colorScheme) var colorScheme
     
@@ -55,6 +56,25 @@ struct Intro: View {
             events: []
         )
     }
+    
+    var monthlyRateTextInput: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.secondary.opacity(0.2))
+            TextField("Enter amount", text: $monthlyRateString)
+                .inputView(
+                    CalculatorKeyboard.self,
+                    text: $monthlyRateString,
+                    onSubmit: {
+                        focusedField = false
+                        currentPage = 2
+                    }
+                )
+                .focused($focusedField)
+                .padding()
+        }
+    }
+    
     var body: some View {
         ZStack {
             LinearGradient(gradient: Gradient(colors: gradientColors),
@@ -81,11 +101,7 @@ struct Intro: View {
                                 
                                 HStack {
                                     Text("$")
-                                    TextField("Enter amount", text: $monthlyRateString)
-                                        .keyboardType(.decimalPad)
-                                        .padding()
-                                        .background(Color.white.opacity(0.2))
-                                        .cornerRadius(10)
+                                    monthlyRateTextInput
                                 }
                             }
                             .padding()
@@ -132,18 +148,20 @@ struct Intro: View {
                     Spacer()
                     
                     // Next/Finish button
-                    Button(action: {
-                        currentPage = min(currentPage + 1, 3)
-                        if currentPage == 3 {
-                            finishIntro(appData)
+                    if focusedField == false {
+                        Button(action: {
+                            currentPage = min(currentPage + 1, 3)
+                            if currentPage == 3 {
+                                finishIntro(appData)
+                            }
+                        }) {
+                            Text(currentPage == 3 ? "Finish" : "Next")
+                                .padding()
+                                .background(toDouble(monthlyRateString) == nil ? Color.gray : Color.primary)
+                                .cornerRadius(10)
                         }
-                    }) {
-                        Text(currentPage == 3 ? "Finish" : "Next")
-                            .padding()
-                            .background(toDouble(monthlyRateString) == nil ? Color.gray : Color.primary)
-                            .cornerRadius(10)
+                        .disabled(toDouble(monthlyRateString) == nil)
                     }
-                    .disabled(toDouble(monthlyRateString) == nil)
                 }
                 .padding()
             }

--- a/Trickle/SettingsView.swift
+++ b/Trickle/SettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SettingsView: View {
     @Binding var appData: AppData
     @State private var tempMonthlyRate: String
+    @FocusState private var focusedField: Bool
     
     init(appData: Binding<AppData>) {
         _appData = appData
@@ -27,6 +28,14 @@ struct SettingsView: View {
                         Text("Excluding bills and subscriptions")
                             .font(.subheadline)
                         TextField("Enter amount", text: $tempMonthlyRate)
+                            .inputView(
+                                CalculatorKeyboard.self,
+                                text: $tempMonthlyRate,
+                                onSubmit: {
+                                    focusedField = false
+                                }
+                            )
+                            .focused($focusedField)
                             .keyboardType(.decimalPad)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
                             .onChange(of: tempMonthlyRate) { newTempMonthlyRate in

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,10 @@ Ever think:
 3. etc.
 
 Then Trickle Cash is the app for you!
+
+
+Acknowledgements:
+
+- [SwiftUI TextField Input View - Custom Keyboard for TextField - Xcode 14](https://www.youtube.com/watch?v=jNpdpO32Pjs) by KavSoft
+- [Oklab](https://github.com/importRyan/Oklab) by ImportRyan
+- [Expression](https://github.com/nicklockwood/Expression?tab=readme-ov-file) by NickLockwood


### PR DESCRIPTION
- [x] Fix issue when text is selected where text is not overwritten
- [x] maybe extend keyboard to add . focus itself
- [x] maybe extend keyboard to have its own focus code that is used when the user doesn't provide a value
- [x] Make keyboard look good
- [x] add light theme to keyboard
- [x] Add arithmetic operators to keyboard 
- [x] Make keyboard the same height as the default ios keyboard
- [x] rename `var isFocused: Bool` to somethign that communicates that it stores whether we should try to take focus when appearing
- [x] Add +5 and -5 buttons (which should also evaluate the current input with toDouble)
- [x] When doing a multiplication, addition, or division, check if the expression already contained a mathematical operator (besides leading -), and if it does use toDouble to evaluate it eagerly
- [x] disallow operators when not preceded by a number (except - which should be allowed at any position)
- [x] when pressing enter, remove trailing operators
- [x] use the keyboard in settings and intro 